### PR TITLE
Removed properties of that are now in Activity

### DIFF
--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -34,14 +34,6 @@
                 "https://openminds.ebrains.eu/computation/LaunchConfiguration"
             ]
         },
-        "startedAtTime": {
-            "type": "date-time",
-            "_instruction": "Enter the timestamp of when the computation started."
-        },
-        "endedAtTime": {
-            "type": "date-time",
-            "_instruction": "Enter the timestamp of when the computation ended."
-        },
         "startedBy": {
             "_instruction": "Add the person or software agent who launched this computation.",
             "_linkedTypes": [


### PR DESCRIPTION
"startedAtTime" and "endedAtTime" are now part of the Activity Schema in openMINDS_core. I've removed them now from the Computation Schema.