### PR TITLE
Clean up: validation test version

### DIFF
--- a/schemas/localFile.schema.tpl.json
+++ b/schemas/localFile.schema.tpl.json
@@ -16,7 +16,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all data types that are specifially represented in this local file instance.",
+      "_instruction": "Add all data types that are specifically represented in this local file instance.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/DataType"
       ]

--- a/schemas/localFile.schema.tpl.json
+++ b/schemas/localFile.schema.tpl.json
@@ -1,58 +1,58 @@
 {
-    "_type": "https://openminds.ebrains.eu/computation/LocalFile",
-    "_categories": [
-      "fileOrigin"
-    ],
-    "required": [
-      "path",
-      "name"
-    ],
-    "properties": {
-      "contentDescription": {
-        "type": "string",
-        "_instruction": "Enter a short content description for this file instance."
-      },
-      "dataType": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add all data types that are specifially represented in this file.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/controlledTerms/DataType"
-        ]
-      },
-      "format": {
-        "_instruction": "Add the content type of this file instance.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/ContentType"
-        ]
-      },
-      "hash": {
-        "_instruction": "Add the hash that was generated for this file instance.",
-        "_embeddedTypes": [
-          "https://openminds.ebrains.eu/core/Hash"
-        ]
-      },
-      "path": {
-        "type": "string",
-        "_instruction": "Enter the file system path to this file, either an absolute path or a path relative to the working directory."
-      },
-      "name": {
-        "type": "string",
-        "_instruction": "Enter the name of this single file."
-      },
-      "specialUsageRole": {
-        "_instruction": "Add a special usage role for this single file.",
-        "_linkedTypes": [
-           "https://openminds.ebrains.eu/controlledTerms/FileUsageRole"
-        ]
-      },
-      "storageSize": {
-        "_instruction": "Enter the storage size this file instance allocates.",
-        "_embeddedTypes": [
-          "https://openminds.ebrains.eu/core/QuantitativeValue"
-        ]
-      }
+  "_type": "https://openminds.ebrains.eu/computation/LocalFile",
+  "_categories": [
+    "fileOrigin"
+  ],
+  "required": [
+    "name",
+    "path"
+  ],
+  "properties": {
+    "contentDescription": {
+      "type": "string",
+      "_instruction": "Enter a short content description for this local file instance."
+    },
+    "dataType": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all data types that are specifially represented in this local file instance.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/DataType"
+      ]
+    },
+    "format": {
+      "_instruction": "Add the content type of this local file instance.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
+      ]
+    },
+    "hash": {
+      "_instruction": "Add the hash that was generated for this local file instance.",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/core/Hash"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "_instruction": "Enter the name of this local file instance."
+    },   
+    "path": {
+      "type": "string",
+      "_instruction": "Enter the file system path (absolute path or relative to the working directory) to this local file instance."
+    },
+    "specialUsageRole": {
+      "_instruction": "Add the special usage role of this local file instance.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/FileUsageRole"
+      ]
+    },
+    "storageSize": {
+      "_instruction": "Enter the storage size this local file instance allocates.",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/core/QuantitativeValue"
+      ]
     }
   }
+}
   

--- a/schemas/localFile.schema.tpl.json
+++ b/schemas/localFile.schema.tpl.json
@@ -48,7 +48,7 @@
       ]
     },
     "storageSize": {
-      "_instruction": "Enter the storage size this local file instance allocates.",
+      "_instruction": "Enter the storage size of this local file instance.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -33,6 +33,12 @@
       "type": "string",
       "_instruction": "Add the entry point for this validation test version (e.g., the Python class name for a SciUnit test)."
     },
+    "format": {
+      "_instruction": "Add the content type of this validation test version, or the content types of the files composing the validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
+      ]
+    }
     "isAlternativeVersionOf": {
       "type": "array",
       "minItems": 1,
@@ -67,12 +73,6 @@
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
         "https://openminds.ebrains.eu/core/WebResource"
-      ]
-    },    
-    "usedFormat": {
-      "_instruction": "Add the used content type of this validation test version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ContentType"
       ]
     }
   }

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -2,7 +2,7 @@
   "_type": "https://openminds.ebrains.eu/computation/ValidationTestVersion",
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
   "required": [
-    "usedFormat"
+    "format"
   ],
   "properties": {    
     "configuration": {

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -1,79 +1,79 @@
 {
-    "_type": "https://openminds.ebrains.eu/computation/ValidationTestVersion",
-    "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
-    "required": [
-       "format"
-    ],
-    "properties": {
-      "developer": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "If necessary, add one or several developers (person or organization) that contributed to the code implementation of this validation test version. Note that these developers will overwrite the ones provided in the validation test this version belongs to.",
-        "_linkedCategories": [
-          "legalPerson"
-        ]
-      },
-      "digitalIdentifier": {
-        "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/DOI"
-        ]
-      },
-      "format": {
-        "_instruction": "Add the used content type of this validation test version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/ContentType"
-        ]
-      },
-      "isAlternativeVersionOf": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add all validation test versions that can be used alternatively to this one.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/computation/ValidationTestVersion"
-        ]
-      },
-      "isNewVersionOf": {
-        "_instruction": "Add the validation test version preceding this one.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/computation/ValidationTestVersion"
-        ]
-      },
-      "license": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add at least one license for this validation test version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/License"
-        ]
-      },
-      "referenceData": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add the data that define the expected output of this test.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/DOI",
-          "https://openminds.ebrains.eu/core/File",
-          "https://openminds.ebrains.eu/core/FileBundle",
-          "https://openminds.ebrains.eu/core/URL"
-        ]
-      },
-      "entryPoint": {
-          "_instruction": "Add the entry point for this test, for example the Python class name for a SciUnit test.",
-          "type": "string"
-      },
-      "configuration": {
-        "_instruction": "Add any configuration information for this test, for example the arguments to the SciUnit class.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/URL",
-          "https://openminds.ebrains.eu/core/File",
-          "https://openminds.ebrains.eu/core/PropertyValueList",
-          "https://openminds.ebrains.eu/core/Configuration"
-        ]
-      }
+  "_type": "https://openminds.ebrains.eu/computation/ValidationTestVersion",
+  "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
+  "required": [
+    "usedFormat"
+  ],
+  "properties": {    
+    "configuration": {
+      "_instruction": "Add the configuration information for this validation test version (e.g., arguments to the SciUnit class).",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/Configuration",
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/PropertyValueList",
+        "https://openminds.ebrains.eu/core/URL"
+      ]
+    },
+    "developer": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all parties that developed this validation test version. Note that these developers will overwrite the developer list provided for the overarching validation test.",
+      "_linkedCategories": [
+        "legalPerson"
+      ]
+    },
+    "digitalIdentifier": {
+      "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DOI"
+      ]
+    },    
+    "entryPoint": {
+      "type": "string",
+      "_instruction": "Add the entry point for this validation test version (e.g., the Python class name for a SciUnit test)."
+    },
+    "isAlternativeVersionOf": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all validation test versions that can be used alternatively to this validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/ValidationTestVersion"
+      ]
+    },
+    "isNewVersionOf": {
+      "_instruction": "Add the validation test version preceding this validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/ValidationTestVersion"
+      ]
+    },
+    "license": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the license for this validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/License"
+      ]
+    },
+    "referenceData": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the data that define the expected output of this validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DOI",
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle",
+        "https://openminds.ebrains.eu/core/URL"
+      ]
+    },    
+    "usedFormat": {
+      "_instruction": "Add the used content type of this validation test version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
+      ]
     }
+  }
 }

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -38,7 +38,7 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]
-    }
+    },
     "isAlternativeVersionOf": {
       "type": "array",
       "minItems": 1,

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -66,7 +66,7 @@
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
-        "https://openminds.ebrains.eu/core/URL"
+        "https://openminds.ebrains.eu/core/WebResource"
       ]
     },    
     "usedFormat": {

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -52,7 +52,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the license for this validation test version.",
+      "_instruction": "Add the license of this validation test version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/License"
       ]

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -11,7 +11,7 @@
         "https://openminds.ebrains.eu/core/Configuration",
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/PropertyValueList",
-        "https://openminds.ebrains.eu/core/URL"
+        "https://openminds.ebrains.eu/core/WebResource"
       ]
     },
     "developer": {


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order 
- fixed indentation

MAJOR changes:
none

SPECIAL ATTENTION: 
- renamed `format` to `usedFormat`: because format has been used to express the format of the type of schema, e.g. file has a format with instructions to add the content type OF the file, here the instructions ask for USED content types  

CHANGELOG:
- `configuration` & `referenceData` link to `WebResource` instead of `URL`