### PR TITLE
Clean up: workflow execution

### DIFF
--- a/schemas/workflowExecution.schema.tpl.json
+++ b/schemas/workflowExecution.schema.tpl.json
@@ -10,9 +10,9 @@
         "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
       ]
     },
-    "stages": {
+    "stage": {
       "type": "array",
-      "minItems":  2,
+      "minItems":  1,
       "uniqueItems": true,
       "_instruction": "Add all stages that were performed in this workflow execution.",
       "_linkedCategories": [

--- a/schemas/workflowExecution.schema.tpl.json
+++ b/schemas/workflowExecution.schema.tpl.json
@@ -1,29 +1,29 @@
 {
-    "_type": "https://openminds.ebrains.eu/computation/WorkflowExecution",
-    "required": [
-        "stages"
-    ],
-    "properties": {
-        "stages": {
-            "type": "array",
-            "minItems":  1,
-            "uniqueItems": true,
-            "_linkedCategories": [
-                "computationalActivity"
-            ]
-        },
-        "startedBy": {
-            "_instruction": "Add the person or software agent who launched this workflow execution.",
-            "_linkedTypes": [
-                "https://openminds.ebrains.eu/core/Person",
-                "https://openminds.ebrains.eu/computation/SoftwareAgent"
-            ]
-        },
-        "recipe": {
-            "_instruction": "Add the workflow recipe version used for this workflow execution",
-            "_linkedTypes": [
-                "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
-            ]
-        }
+  "_type": "https://openminds.ebrains.eu/computation/WorkflowExecution",
+  "required": [
+    "stages"
+  ],
+  "properties": {    
+    "recipe": {
+      "_instruction": "Add the workflow recipe version used for this workflow execution.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
+      ]
+    },
+    "stages": {
+      "type": "array",
+      "minItems":  2,
+      "uniqueItems": true,
+      "_instruction": "Add all stages that were performed in this workflow execution.",
+      "_linkedCategories": [
+        "computationalActivity"
+      ]
+    },
+    "startedBy": {
+      "_instruction": "Add the agent that started this workflow execution.",
+      "_linkedCategories": [
+        "agent"
+      ]
     }
+  }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order 
- fixed indentation

MAJOR changes:
none

SPECIAL ATTENTION: 
- changed `minItems` for `stages` from 1 to 2 because I don't think that a single activity qualifies as a workflow, does it @apdavison? If it should, I'll change it back but change the property name to `stage` (to stick to our convention)

CHANGELOG:
- changed `stages` to `stage` as requested by @apdavison and change `minItems` back to 1
