### PR TITLE
Clean up: workflow recipe version

### DIFF
--- a/schemas/workflowRecipeVersion.schema.tpl.json
+++ b/schemas/workflowRecipeVersion.schema.tpl.json
@@ -2,7 +2,7 @@
   "_type": "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion",
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
   "required": [
-    "usedFormat"
+    "format"
   ],
   "properties": {
     "developer": {
@@ -18,6 +18,12 @@
       "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI"
+      ]
+    },    
+    "format": {
+      "_instruction": "Add the content type of this workflow recipe version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
       ]
     },
     "hasComponent": {
@@ -55,12 +61,6 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/License"
       ]
-    },
-    "usedFormat": {
-      "_instruction": "Add the used content type of this workflow recipe version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ContentType"
-      ]
-    },
+    }
   }
 }

--- a/schemas/workflowRecipeVersion.schema.tpl.json
+++ b/schemas/workflowRecipeVersion.schema.tpl.json
@@ -1,66 +1,66 @@
 {
-    "_type": "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion",
-    "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
-    "required": [
-       "format"
-    ],
-    "properties": {
-      "developer": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "If necessary, add one or several developers (person or organization) that contributed to the code implementation of this workflow recipe version. Note that these developers will overwrite the ones provided in the workflow recipe this version belongs to.",
-        "_linkedCategories": [
-          "legalPerson"
-        ]
-      },
-      "digitalIdentifier": {
-        "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/DOI"
-        ]
-      },
-      "hasComponent": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add all workflow recipe versions that are components of this workflow recipe version, as well as the software and/or scripts used in this workflow",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion",
-          "https://openminds.ebrains.eu/core/SoftwareVersion",
-          "https://openminds.ebrains.eu/core/File",
-          "https://openminds.ebrains.eu/core/FileBundle"
-        ]
-      },
-      "format": {
-        "_instruction": "Add the used content type of this workflow recipe version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/ContentType"
-        ]
-      },
-      "isAlternativeVersionOf": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add all workflow recipe versions that can be used alternatively to this workflow recipe version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
-        ]
-      },
-      "isNewVersionOf": {
-        "_instruction": "Add the workflow recipe version preceding this one.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
-        ]
-      },
-      "license": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "_instruction": "Add at least one license for this workflow recipe version.",
-        "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/License"
-        ]
-      }
-    }
+  "_type": "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion",
+  "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
+  "required": [
+    "usedFormat"
+  ],
+  "properties": {
+    "developer": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all parties that developed this workflow recipe version. Note that these developers will overwrite the developer list provided for the overarching workflow recipe.",
+      "_linkedCategories": [
+        "legalPerson"
+      ]
+    },
+    "digitalIdentifier": {
+      "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DOI"
+      ]
+    },
+    "hasComponent": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all entities that are components of this workflow recipe version (e.g., other workflow recipe versions or software used in this workflow).",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion",        
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle",
+        "https://openminds.ebrains.eu/core/SoftwareVersion"
+      ]
+    },
+    "isAlternativeVersionOf": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all workflow recipe versions that can be used alternatively to this workflow recipe version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
+      ]
+    },
+    "isNewVersionOf": {
+      "_instruction": "Add the workflow recipe version preceding this workflow recipe version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/WorkflowRecipeVersion"
+      ]
+    },
+    "license": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all licenses of this workflow recipe version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/License"
+      ]
+    },
+    "usedFormat": {
+      "_instruction": "Add the used content type of this workflow recipe version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
+      ]
+    },
   }
+}


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- fixed indentation

MAJOR changes:
none

SPECIAL ATTENTION:
- renamed `format` to `usedFormat`: because format has been used to express the format of the type of schema, e.g. file has a format with instructions to add the content type OF the file, here the instructions ask for USED content types