### PR TITLE
update of computation extension due to feedback from the siibra-team

### DIFF
--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -71,6 +71,15 @@
         "type": "string"
       }
     },
+    "technique": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add one or several analysis techniques that were used in this computation.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/AnalysisTechnique"
+      ]
+    },
     "wasInformedBy": {
       "_instruction": "Add another computation that sent data to this one during runtime.",
       "_linkedCategories": [

--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -2,7 +2,6 @@
   "_extends": "/core/schemas/research/activity.schema.tpl.json",
   "required": [
     "environment",
-    "launchConfiguration",
     "startTime"
   ],
   "properties": {

--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -8,7 +8,8 @@
     "environment": {
       "_instruction": "Add the computational environment in which this computation was executed.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/computation/Environment"
+        "https://openminds.ebrains.eu/computation/Environment",
+        "https://openminds.ebrains.eu/core/WebServiceVersion"
       ]
     },
     "input": {          

--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -75,7 +75,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or several analysis techniques that were used in this computation.",
+      "_instruction": "Add all analysis techniques that were used in this computation.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/AnalysisTechnique"
       ]

--- a/schemas/computation.schema.tpl.json
+++ b/schemas/computation.schema.tpl.json
@@ -30,6 +30,7 @@
       "_linkedTypes": [        
         "https://openminds.ebrains.eu/computation/LocalFile",
         "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileArchive",
         "https://openminds.ebrains.eu/core/FileBundle"
       ]
     },    

--- a/schemas/dataAnalysis.schema.tpl.json
+++ b/schemas/dataAnalysis.schema.tpl.json
@@ -3,5 +3,17 @@
   "_extends": "computation.schema.tpl.json",
   "_categories": [
     "computationalActivity"
-  ]
+  ],
+  "properties": {
+    "input": {          
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/computation/LocalFile",
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle",
+        "https://openminds.ebrains.eu/core/SoftwareVersion",
+        "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
The siibra team would like to use the computation extension to register transformation procedures for EBRAINS data to EBRAINS atlases. They are missing some input / outputs and some of the current requirements do not fit.

Update includes:
+ Computation: 
   - adding FileArchive to possible "output"
   - making "launchConfiguration" optional property
   - adding WebServiceVersion to possible "environment"
   - adding property "technique" with linkedType AnalysisTechnique (requires also PR in controlledTerms)
+ DataAnalysis:
   - overwriting "input" to also contain CommonCoordinatSpaceVersion and BrainAtlasVersion
