### PR TITLE
Add "copyOf" property to LocalFile

### DIFF
--- a/schemas/localFile.schema.tpl.json
+++ b/schemas/localFile.schema.tpl.json
@@ -12,6 +12,12 @@
       "type": "string",
       "_instruction": "Enter a short content description for this local file instance."
     },
+    "copyOf": {
+      "_instruction": "Add the file of which this is a copy.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/File"
+      ]
+    },
     "dataType": {
       "type": "array",
       "minItems": 1,
@@ -36,7 +42,7 @@
     "name": {
       "type": "string",
       "_instruction": "Enter the name of this local file instance."
-    },   
+    },
     "path": {
       "type": "string",
       "_instruction": "Enter the file system path (absolute path or relative to the working directory) to this local file instance."
@@ -55,4 +61,3 @@
     }
   }
 }
-  


### PR DESCRIPTION
In workflows, we often work with files that have been downloaded from EBRAINS storage, and that are registered in the KG. Similarly, files generated during workflows may later be uploaded and registered. 

For the purposes of reproducibility, we need to record the local path of the file. I propose to handle this by adding a "copyOf" property to the LocalFile schema, allowing to link a representation of a local copy of a file (with path information) to the canonical representation of the File in the KG.
