### PR TITLE
switch connection between RP and RPVs

### DIFF
--- a/schemas/validationTest.schema.tpl.json
+++ b/schemas/validationTest.schema.tpl.json
@@ -20,15 +20,6 @@
         "core:DOI"
       ]
     },
-    "hasVersion": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all versions of this validation test.",
-      "_linkedTypes": [
-        "computation:ValidationTestVersion"
-      ]
-    },
     "referenceDataAcquisition": {
       "type": "array",
       "minItems": 1,
@@ -43,7 +34,7 @@
       "_linkedTypes": [
         "controlledTerms:ModelScope"
       ]
-    },   
+    },
     "scoreType": {
       "_instruction": "Add the type of score calculated in this validation test.",
       "_linkedTypes": [

--- a/schemas/validationTestVersion.schema.tpl.json
+++ b/schemas/validationTestVersion.schema.tpl.json
@@ -4,7 +4,7 @@
   "required": [
     "format"
   ],
-  "properties": {    
+  "properties": {
     "configuration": {
       "_instruction": "Add the configuration information for this validation test version (e.g., arguments to the SciUnit class).",
       "_linkedTypes": [
@@ -28,7 +28,7 @@
       "_linkedTypes": [
         "core:DOI"
       ]
-    },    
+    },
     "entryPoint": {
       "type": "string",
       "_instruction": "Add the entry point for this validation test version (e.g., the Python class name for a SciUnit test)."
@@ -39,7 +39,13 @@
         "core:ContentType"
       ]
     },
-    "isAlternativeVersionOf": {
+    "isPrecededBy": {
+      "_instruction": "Add the validation test version preceding this validation test version.",
+      "_linkedTypes": [
+        "computation:ValidationTestVersion"
+      ]
+    },
+    "isVariantOf": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
@@ -48,10 +54,10 @@
         "computation:ValidationTestVersion"
       ]
     },
-    "isNewVersionOf": {
-      "_instruction": "Add the validation test version preceding this validation test version.",
+    "isVersionOf": {
+      "_instruction": "Add the version-independent information about this validation test.",
       "_linkedTypes": [
-        "computation:ValidationTestVersion"
+        "computation:ValidationTest"
       ]
     },
     "license": {

--- a/schemas/workflowRecipe.schema.tpl.json
+++ b/schemas/workflowRecipe.schema.tpl.json
@@ -19,15 +19,6 @@
       "_linkedTypes": [
         "core:DOI"
       ]
-    },
-    "hasVersion": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all versions of this workflow recipe.",
-      "_linkedTypes": [
-        "computation:WorkflowRecipeVersion"
-      ]
     }
   }
 }

--- a/schemas/workflowRecipeVersion.schema.tpl.json
+++ b/schemas/workflowRecipeVersion.schema.tpl.json
@@ -19,7 +19,7 @@
       "_linkedTypes": [
         "core:DOI"
       ]
-    },    
+    },
     "format": {
       "_instruction": "Add the content type of this workflow recipe version.",
       "_linkedTypes": [
@@ -32,13 +32,19 @@
       "uniqueItems": true,
       "_instruction": "Add all entities that are components of this workflow recipe version (e.g., other workflow recipe versions or software used in this workflow).",
       "_linkedTypes": [
-        "computation:WorkflowRecipeVersion",        
+        "computation:WorkflowRecipeVersion",
         "core:File",
         "core:FileBundle",
         "core:SoftwareVersion"
       ]
     },
-    "isAlternativeVersionOf": {
+    "isPrecededBy": {
+      "_instruction": "Add the workflow recipe version preceding this workflow recipe version.",
+      "_linkedTypes": [
+        "computation:WorkflowRecipeVersion"
+      ]
+    },
+    "isVariantOf": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
@@ -47,10 +53,10 @@
         "computation:WorkflowRecipeVersion"
       ]
     },
-    "isNewVersionOf": {
-      "_instruction": "Add the workflow recipe version preceding this workflow recipe version.",
+    "isVersionOf": {
+      "_instruction": "Add the version-independent information about this workflow recipe.",
       "_linkedTypes": [
-        "computation:WorkflowRecipeVersion"
+        "computation:Workflow"
       ]
     },
     "license": {


### PR DESCRIPTION
RPVs now refer to their parent RP with isVersionOf. We remove hasVersion from the RP.

Related to openMetadataInitiative/openMINDS_core#553